### PR TITLE
hotfix-sesame: add trim() so newlines don't mess things up

### DIFF
--- a/nc-multiplex.js
+++ b/nc-multiplex.js
@@ -205,7 +205,7 @@ try {
 //
 try {
   let sesame = fs.readFileSync('SESAME', 'utf8');
-  PASSWORD = sesame;
+  PASSWORD = sesame.trim();
 } catch (err) {
   // no password, use default
   PASSWORD = DEFAULT_PASSWORD;


### PR DESCRIPTION
The "custom passphrase" feature does not trim whitespace, which causes problems in matching passwords.